### PR TITLE
adjusting default position for x.com mobile

### DIFF
--- a/inject.css
+++ b/inject.css
@@ -23,6 +23,13 @@
   top: 10px;
 }
 
+/* x.com */
+/* moves vsc out from underneath the back button on x.com mobile browser */
+[data-testid="videoComponent"] .vsc-controller {
+  position: relative;
+  top: 50px;
+}
+
 .ytp-autohide .vsc-controller {
   visibility: hidden;
   transition: opacity 0.25s cubic-bezier(0.4, 0, 0.2, 1);


### PR DESCRIPTION
the video speed controller on x.com would appear underneath the back button in fullscreen when using a mobile browser that allows extensions (e.g. kiwi browser). 

This patch uses a domain-specific override to shift the default position down so that it is usable in this specific case. It is no longer stuck underneath the back button.

**note:** it is recommended for the user to remove twitter.com from the disabled sites list in the options page in the UI of the extension.